### PR TITLE
Fix build-all.sh: use bash rather than sh

### DIFF
--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*}/bin"

--- a/tools/clients/h1load/build.sh
+++ b/tools/clients/h1load/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*/*/*}/bin"

--- a/tools/clients/wrk2/build.sh
+++ b/tools/clients/wrk2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*/*/*}/bin"

--- a/tools/measures/if_rate/build.sh
+++ b/tools/measures/if_rate/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*/*/*}/bin"

--- a/tools/measures/vmstat/build.sh
+++ b/tools/measures/vmstat/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*/*/*}/bin"

--- a/tools/servers/httpterm/build.sh
+++ b/tools/servers/httpterm/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*/*/*}/bin"


### PR DESCRIPTION
Before this change, running ./tools/build-all.sh on Ubuntu 20.04 causes
this error:

./tools/build-all.sh: 6: Syntax error: "(" unexpected

This is fixed by changing the shebang to #!/bin/bash.