### PR TITLE
fixing tools/build-all.sh shebang for ubuntu 20.04

### DIFF
--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd -P $(dirname $0)
 BIN="${PWD%/*}/bin"


### PR DESCRIPTION
I am unable to run buidl-all.sh on Ubuntu 20.04 with its default
shell set to dash now, instead of bash:

$ ./tools/build-all.sh
./tools/build-all.sh: 6: Syntax error: "(" unexpected

$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Aug  4  2020 /bin/sh -> dash